### PR TITLE
feat: Create Firefox extension to bypass linksynergy for Udemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore build artifacts from web-ext
+web-ext-artifacts/
+
+# Ignore node_modules directory
+node_modules/

--- a/background.js
+++ b/background.js
@@ -1,0 +1,36 @@
+function redirect(requestDetails) {
+  try {
+    const url = new URL(requestDetails.url);
+    const murl = url.searchParams.get('murl');
+
+    if (murl) {
+      // The murl parameter is expected to be a URL-encoded string.
+      const decodedUrl = decodeURIComponent(murl);
+
+      // Check if the decoded URL is a Udemy course link.
+      // This is a safety check to ensure we only redirect to Udemy.
+      if (decodedUrl.startsWith('https://www.udemy.com/course/')) {
+        console.log(`Linksynergy Redirector: Found Udemy link. Redirecting to: ${decodedUrl}`);
+        return {
+          redirectUrl: decodedUrl
+        };
+      }
+    }
+  } catch (e) {
+    console.error(`Linksynergy Redirector: Error processing request ${requestDetails.url}`, e);
+  }
+
+  // If no 'murl' is found, or it's not a Udemy link,
+  // let the request proceed as normal.
+  return {};
+}
+
+// Add a listener for web requests to linksynergy.com domains.
+browser.webRequest.onBeforeRequest.addListener(
+  redirect,
+  {
+    urls: ["*://*.linksynergy.com/*"],
+    types: ["main_frame"] // Only apply to top-level navigation
+  },
+  ["blocking"] // This option is required to modify the request.
+);

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "Linksynergy to Udemy Redirector",
+  "version": "1.0",
+  "description": "Redirects linksynergy.com affiliate links directly to the final Udemy course page, bypassing the tracker.",
+  "permissions": [
+    "webRequest"
+  ],
+  "host_permissions": [
+    "*://*.linksynergy.com/*"
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "linksynergy-redirector@jules.dev"
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces a new Firefox web extension that automatically bypasses `linksynergy.com` affiliate links and redirects directly to the final Udemy course page.

The extension works by intercepting web requests to `*.linksynergy.com`. It then parses the URL, extracts the destination URL from the `murl` query parameter, and if it points to a Udemy course, it redirects the browser to that URL.

This solves the issue where adblockers might prevent `linksynergy.com` links from resolving, allowing the user to access the Udemy course directly while preserving any coupon codes included in the link.

The extension is built using Manifest V3 and includes:
- `manifest.json`: Defines the extension, its permissions, and background script.
- `background.js`: Contains the core logic for intercepting and redirecting requests.
- `.gitignore`: Excludes build artifacts from the repository.