### PR TITLE
ci: Add GitHub Action to build extension

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,0 +1,29 @@
+name: Build Firefox Extension
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build the extension
+        id: build_extension
+        run: npx web-ext build --source-dir . --artifacts-dir ./web-ext-artifacts
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: udemy-redirector-extension
+          path: ./web-ext-artifacts/


### PR DESCRIPTION
This commit introduces a GitHub Actions workflow to automate the packaging of the Firefox extension.

The workflow is defined in `.github/workflows/build-extension.yml` and will:
- Trigger on every push to the `main` branch.
- Check out the code.
- Set up a Node.js environment.
- Use `npx web-ext build` to package the extension source code into a zip file.
- Upload the generated zip file as a build artifact named `udemy-redirector-extension`.

This allows for continuous integration and makes it easy to download a ready-to-install version of the extension directly from the repository's actions tab.